### PR TITLE
feat: add What's New popup, dev build preview, and release automation (#37)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,8 +1,8 @@
-name: Deploy to GitHub Pages
+name: Deploy Dev to GitHub Pages
 
 on:
   push:
-    branches: [main]
+    branches: [dev]
 
 permissions:
   contents: write
@@ -16,10 +16,10 @@ jobs:
         with:
           channel: stable
       - run: flutter pub get
-      - run: flutter build web --base-href "/aadat/"
+      - run: flutter build web --base-href "/aadat/dev/"
       - uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: build/web
           branch: gh-pages
-          # Preserve the /dev/ subfolder when deploying from main.
-          clean-exclude: dev
+          # Deploy into the /dev/ subfolder, leaving the root (main) untouched.
+          target-folder: dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Create GitHub Release
+
+# Runs after every push to main. If pubspec.yaml's version changed compared
+# to the previous commit, a GitHub Release + tag are created automatically.
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # need HEAD and HEAD^ to compare versions
+
+      - name: Read current version
+        id: current
+        run: |
+          echo "version=$(grep '^version:' pubspec.yaml | awk '{print $2}' | tr -d '\r')" >> $GITHUB_OUTPUT
+
+      - name: Read previous version
+        id: previous
+        run: |
+          echo "version=$(git show HEAD^:pubspec.yaml | grep '^version:' | awk '{print $2}' | tr -d '\r')" >> $GITHUB_OUTPUT
+
+      - name: Create release if version changed
+        if: steps.current.outputs.version != steps.previous.outputs.version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=${{ steps.current.outputs.version }}
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
+            --generate-notes

--- a/.github/workflows/validate-release-pr.yml
+++ b/.github/workflows/validate-release-pr.yml
@@ -1,0 +1,50 @@
+name: Validate Release PR
+
+# Runs on every PR targeting main to enforce that the version is bumped
+# and the in-app changelog is updated before anything ships to users.
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Versions match (pubspec.yaml ↔ changelog.dart)
+        run: |
+          PUBSPEC=$(grep '^version:' pubspec.yaml | awk '{print $2}' | tr -d '\r')
+          DART=$(grep -oP "(?<=kAppVersion = ')[^']+" lib/data/changelog.dart)
+
+          if [ "$PUBSPEC" != "$DART" ]; then
+            echo "❌ Version mismatch:"
+            echo "   pubspec.yaml  → $PUBSPEC"
+            echo "   changelog.dart → $DART"
+            echo ""
+            echo "Run scripts/prepare_release.sh $PUBSPEC to fix."
+            exit 1
+          fi
+          echo "✅ Versions match: $PUBSPEC"
+
+      - name: kChangelog has entry for this version
+        run: |
+          VERSION=$(grep '^version:' pubspec.yaml | awk '{print $2}' | tr -d '\r')
+          if ! grep -q "'$VERSION'" lib/data/changelog.dart; then
+            echo "❌ No kChangelog entry for version $VERSION in lib/data/changelog.dart."
+            echo "   Add one before merging to main."
+            exit 1
+          fi
+          echo "✅ kChangelog entry present for $VERSION"
+
+      - name: Version was actually bumped (vs. base branch)
+        run: |
+          BASE_VERSION=$(git show origin/${{ github.base_ref }}:pubspec.yaml | grep '^version:' | awk '{print $2}' | tr -d '\r')
+          HEAD_VERSION=$(grep '^version:' pubspec.yaml | awk '{print $2}' | tr -d '\r')
+
+          if [ "$BASE_VERSION" = "$HEAD_VERSION" ]; then
+            echo "❌ pubspec.yaml version was not bumped (still $HEAD_VERSION)."
+            echo "   Run scripts/prepare_release.sh <new_version> before merging to main."
+            exit 1
+          fi
+          echo "✅ Version bumped: $BASE_VERSION → $HEAD_VERSION"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,238 @@
+# Contributing
+
+This document covers the full development workflow: branch naming, the feature → dev → main flow, what is automated by CI, and step-by-step instructions for each stage.
+
+---
+
+## Branches
+
+| Branch | Purpose |
+|--------|---------|
+| `main` | Production. Every merge here deploys to users and may trigger a release. |
+| `dev` | Integration. All feature and fix branches target this. |
+| `feat/<issue#>-<description>` | A new feature tied to a GitHub issue. |
+| `fix/<issue#>-<description>` | A bug fix tied to a GitHub issue. |
+| `chore/<issue#>-<description>` | Maintenance work (deps, config, refactors, docs). |
+
+**Examples**
+
+```
+feat/42-custom-recurrence
+fix/17-day-picker-not-showing
+chore/8-update-dependencies
+```
+
+Rules:
+- Always branch off `dev`, never off `main`.
+- Use lowercase and hyphens only — no spaces, no uppercase.
+- Include the issue number so the branch is traceable.
+
+---
+
+## Flow overview
+
+```
+feat/42-...  ─┐
+fix/17-...   ─┤──► dev ──────────────────────► main ──► GitHub Pages /aadat/ (live to users)
+chore/8-...  ─┘     │                            │
+                     │                            └──► GitHub Release (created automatically)
+                     └──► GitHub Pages /aadat/dev/ (preview build)
+```
+
+Feature and fix branches feed into `dev`. Every push to `dev` automatically deploys a preview build so you can test changes before they reach users. When enough changes have accumulated, `dev` is merged into `main` as a release, which deploys to the live URL.
+
+---
+
+## Day-to-day: working on a feature or fix
+
+### 1. Create a GitHub issue
+
+Before starting any work, open an issue describing what you are building or fixing. Note the issue number — you will use it in your branch name.
+
+### 2. Create a branch from `dev`
+
+```bash
+git checkout dev
+git pull origin dev
+git checkout -b feat/42-custom-recurrence
+```
+
+### 3. Write and commit your changes
+
+Follow the **Conventional Commits** format. This is important — the release script uses these commit messages to auto-suggest changelog entries.
+
+| Prefix | When to use |
+|--------|-------------|
+| `feat:` | A new feature visible to users |
+| `fix:` | A bug fix |
+| `chore:` | Dependency updates, config changes, refactors, docs |
+
+```bash
+git commit -m "feat: add custom recurrence day picker"
+git commit -m "fix: hide day picker when recurrence is not custom"
+```
+
+One logical change per commit. Avoid commits like "wip" or "misc changes".
+
+### 4. Open a pull request into `dev`
+
+Title your PR the same way you would a commit:
+
+```
+feat: add custom recurrence day picker (#42)
+```
+
+In the PR body, add a closing keyword so the issue closes automatically on merge:
+
+```
+Closes #42
+```
+
+### 5. Merge into `dev`
+
+Review the diff, then merge. Squash if the branch has noisy intermediate commits; merge commit if each commit is meaningful on its own.
+
+Merging triggers `deploy-dev.yml`, which builds and deploys the updated `dev` branch to the preview URL. Use this to test your changes before they ship.
+
+### 6. Test on the dev build
+
+Open the live app, go to **Settings → Developer → Open dev build**. This navigates to the `/aadat/dev/` preview URL where your merged changes are live.
+
+If you want others to preview a change before it merges, share the dev URL directly: `https://<username>.github.io/aadat/dev/`
+
+### 7. Track unreleased changes in `kDevChangelog`
+
+As you merge features and fixes into `dev`, add a plain-English entry to `kDevChangelog` in `lib/data/changelog.dart`:
+
+```dart
+const List<ChangeEntry> kDevChangelog = [
+  ChangeEntry(ChangeType.feature, 'Custom recurrence — pick specific days of the week'),
+  ChangeEntry(ChangeType.fix, 'Day picker now hides when recurrence is not Custom'),
+];
+```
+
+This list has no user-facing effect — it is only visible in the Developer section of Settings. When you release, move these entries into `kChangelog` under the new version key and clear `kDevChangelog`.
+
+---
+
+## Releasing: merging `dev` into `main`
+
+Do this when you have accumulated enough changes on `dev` that you want to ship them to users.
+
+### 1. Decide the new version number
+
+Use [Semantic Versioning](https://semver.org): `MAJOR.MINOR.PATCH`
+
+| Change | Bump |
+|--------|------|
+| Breaking change or major redesign | MAJOR (`1.0.0 → 2.0.0`) |
+| New feature | MINOR (`0.1.0 → 0.2.0`) |
+| Bug fix only | PATCH (`0.1.0 → 0.1.1`) |
+
+When in doubt, a release that contains any new features is a MINOR bump.
+
+### 2. Run the release preparation script
+
+From the root of the repo:
+
+```bash
+./scripts/prepare_release.sh 0.2.0
+```
+
+This script:
+- Updates the version in `pubspec.yaml`
+- Updates `kAppVersion` in `lib/data/changelog.dart`
+- Prints suggested `kChangelog` entries generated from your conventional commits since the last release
+
+### 3. Update the in-app changelog
+
+Open `lib/data/changelog.dart`. The script output will look like:
+
+```dart
+  '0.2.0': [
+    ChangeEntry(ChangeType.feature, 'add custom recurrence day picker'),
+    ChangeEntry(ChangeType.fix, 'hide day picker when recurrence is not custom'),
+  ],
+```
+
+Paste this block into `kChangelog` and **rewrite the descriptions in plain English for users** — not developer commit messages. For example:
+
+```dart
+  '0.2.0': [
+    ChangeEntry(ChangeType.feature, 'Custom recurrence — pick specific days of the week for a habit'),
+    ChangeEntry(ChangeType.fix, 'Day picker now stays hidden unless Custom recurrence is selected'),
+  ],
+```
+
+### 4. Commit and push
+
+```bash
+git add pubspec.yaml lib/data/changelog.dart
+git commit -m "chore: release v0.2.0"
+git push origin dev
+```
+
+### 5. Open a pull request: `dev` → `main`
+
+Title:
+
+```
+release: v0.2.0
+```
+
+No issue number needed for release PRs. CI will automatically validate:
+
+- `kAppVersion` in `changelog.dart` matches `pubspec.yaml`
+- `kChangelog` has an entry for the new version
+- The version was actually bumped relative to `main`
+
+If any check fails, fix the issue and push to the branch — CI reruns automatically.
+
+### 6. Merge into `main`
+
+Once CI passes, merge the PR. This triggers two automated actions:
+
+1. **Deploy** — `deploy.yml` builds Flutter Web and publishes to GitHub Pages. Users get the new version within a few minutes.
+2. **Release** — `release.yml` detects the version bump and creates a GitHub Release with an auto-generated summary of merged PRs.
+
+The What's New popup will appear the next time each user opens the app — it compares the shipped `kAppVersion` against the version stored in their browser's local storage.
+
+---
+
+## CI at a glance
+
+| Workflow | Trigger | What it does |
+|----------|---------|--------------|
+| `deploy-dev.yml` | Push to `dev` | Builds Flutter Web and deploys to `/aadat/dev/` (preview) |
+| `validate-release-pr.yml` | PR to `main` | Blocks merge if version not bumped, `kAppVersion` mismatches `pubspec.yaml`, or `kChangelog` entry is missing |
+| `deploy.yml` | Push to `main` | Builds Flutter Web and deploys to `/aadat/` (live), preserving the `/dev/` subfolder |
+| `release.yml` | Push to `main` | Creates a GitHub Release + tag if the version changed |
+
+### One-time GitHub Pages setup
+
+The deploy workflows write to a `gh-pages` branch rather than using GitHub's built-in Actions deployment. This is what enables deploying to separate subfolders for `main` and `dev`.
+
+After the first deploy runs and creates the `gh-pages` branch, update the GitHub Pages source:
+
+1. Go to **Settings → Pages → Build and deployment → Source**
+2. Switch from `GitHub Actions` to `Deploy from a branch`
+3. Set branch to `gh-pages`, folder to `/ (root)`
+
+---
+
+## Quick reference
+
+```bash
+# Start a feature
+git checkout dev && git pull origin dev
+git checkout -b feat/42-description
+
+# Commit
+git commit -m "feat: description of change"
+
+# Prepare a release (run on dev branch)
+./scripts/prepare_release.sh 0.2.0
+# → edit lib/data/changelog.dart with user-facing descriptions
+git add pubspec.yaml lib/data/changelog.dart
+git commit -m "chore: release v0.2.0"
+```

--- a/lib/data/changelog.dart
+++ b/lib/data/changelog.dart
@@ -1,0 +1,30 @@
+/// Bump [kAppVersion] and add an entry here whenever you push to main.
+/// Keep this in sync with the version in pubspec.yaml.
+const String kAppVersion = '0.1.0';
+
+enum ChangeType { feature, fix }
+
+class ChangeEntry {
+  final ChangeType type;
+  final String description;
+  const ChangeEntry(this.type, this.description);
+}
+
+/// Changes currently on the dev branch that have not yet shipped to users.
+/// Add entries here as you build. When releasing, move them into [kChangelog]
+/// under the new version key and clear this list.
+const List<ChangeEntry> kDevChangelog = [
+  // Example:
+  // ChangeEntry(ChangeType.feature, 'Something being built on dev'),
+];
+
+/// Maps version strings to the list of changes introduced in that version.
+/// The popup shows the entry for [kAppVersion] whenever a user updates.
+const Map<String, List<ChangeEntry>> kChangelog = {
+  '0.1.0': [
+    ChangeEntry(ChangeType.feature, 'Custom recurrence — pick specific days of the week for a habit'),
+    ChangeEntry(ChangeType.feature, 'Day notes — attach a note to any habit on any day in the Calendar'),
+    ChangeEntry(ChangeType.feature, 'About page'),
+    ChangeEntry(ChangeType.fix, 'End date is now validated against the habit start date'),
+  ],
+};

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:aadat/ui/home/view_models/home_viewmodel.dart';
 import 'package:aadat/ui/home/widgets/home_page.dart';
+import 'package:aadat/ui/whats_new_dialog.dart';
 import 'package:flutter/material.dart';
 import 'package:aadat/ui/home/widgets/calendar_page.dart';
 import 'package:aadat/ui/home/widgets/habits_page.dart';
@@ -150,6 +151,14 @@ class Router extends StatefulWidget {
 
 class _RouterState extends State<Router> {
   var selectedIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) checkAndShowWhatsNew(context);
+    });
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/ui/settings/settings_dialog.dart
+++ b/lib/ui/settings/settings_dialog.dart
@@ -1,8 +1,10 @@
 import 'package:aadat/data/repositories/habit_model.dart';
 import 'package:aadat/ui/home/view_models/home_viewmodel.dart';
 import 'package:aadat/ui/settings/settings_viewmodel.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 /// Explains duplicate title rejection from [HabitService].
 Future<void> showDuplicateHabitNameDialog(BuildContext context) {
@@ -261,6 +263,31 @@ class _AppSettingsDialog extends StatelessWidget {
                   );
                 },
               ),
+              if (kIsWeb) ...[
+                const SizedBox(height: 16),
+                Divider(color: scheme.outlineVariant.withValues(alpha: 0.5)),
+                const SizedBox(height: 12),
+                Text(
+                  'Developer',
+                  style: textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    color: scheme.onSurfaceVariant,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  title: const Text('Open dev build'),
+                  subtitle: const Text(
+                    'Switch to the dev branch build to test unreleased changes.',
+                  ),
+                  trailing: const Icon(Icons.open_in_new, size: 18),
+                  onTap: () {
+                    final devUri = Uri.base.resolve('dev/');
+                    launchUrl(devUri, webOnlyWindowName: '_self');
+                  },
+                ),
+              ],
             ],
           ),
         ),

--- a/lib/ui/whats_new_dialog.dart
+++ b/lib/ui/whats_new_dialog.dart
@@ -1,0 +1,137 @@
+import 'package:aadat/data/changelog.dart';
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const _kLastSeenVersionKey = 'last_seen_version';
+
+/// Call once on app startup (after the first frame).
+/// - First install: silently records the current version; no popup shown.
+/// - Version upgrade: shows the What's New dialog, then records the version.
+Future<void> checkAndShowWhatsNew(BuildContext context) async {
+  final prefs = await SharedPreferences.getInstance();
+  final lastSeen = prefs.getString(_kLastSeenVersionKey);
+
+  if (lastSeen == null) {
+    // First install — record version without showing anything.
+    await prefs.setString(_kLastSeenVersionKey, kAppVersion);
+    return;
+  }
+
+  if (lastSeen == kAppVersion) return;
+
+  final entries = kChangelog[kAppVersion];
+  if (entries == null || entries.isEmpty) {
+    await prefs.setString(_kLastSeenVersionKey, kAppVersion);
+    return;
+  }
+
+  if (!context.mounted) return;
+
+  await showDialog<void>(
+    context: context,
+    builder: (ctx) => _WhatsNewDialog(entries: entries),
+  );
+
+  await prefs.setString(_kLastSeenVersionKey, kAppVersion);
+}
+
+class _WhatsNewDialog extends StatelessWidget {
+  const _WhatsNewDialog({required this.entries});
+
+  final List<ChangeEntry> entries;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    final features = entries.where((e) => e.type == ChangeType.feature).toList();
+    final fixes = entries.where((e) => e.type == ChangeType.fix).toList();
+
+    return AlertDialog(
+      title: Row(
+        children: [
+          Icon(Icons.auto_awesome_outlined, color: scheme.primary),
+          const SizedBox(width: 10),
+          const Text("What's New"),
+        ],
+      ),
+      content: SizedBox(
+        width: 420,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Version $kAppVersion',
+                style: textTheme.bodySmall?.copyWith(color: scheme.onSurfaceVariant),
+              ),
+              if (features.isNotEmpty) ...[
+                const SizedBox(height: 14),
+                Text(
+                  'New',
+                  style: textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    color: scheme.onSurfaceVariant,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                ...features.map((e) => _ChangeRow(entry: e)),
+              ],
+              if (fixes.isNotEmpty) ...[
+                const SizedBox(height: 10),
+                Text(
+                  'Fixed',
+                  style: textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    color: scheme.onSurfaceVariant,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                ...fixes.map((e) => _ChangeRow(entry: e)),
+              ],
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Got it'),
+        ),
+      ],
+    );
+  }
+}
+
+class _ChangeRow extends StatelessWidget {
+  const _ChangeRow({required this.entry});
+
+  final ChangeEntry entry;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    final isFeature = entry.type == ChangeType.feature;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            isFeature ? Icons.star_outline_rounded : Icons.bug_report_outlined,
+            size: 16,
+            color: isFeature ? scheme.primary : scheme.error,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(entry.description, style: textTheme.bodySmall),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,8 +7,10 @@ import Foundation
 
 import path_provider_foundation
 import shared_preferences_foundation
+import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -164,26 +164,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.18.0"
   nested:
     dependency: transitive
     description:
@@ -377,10 +377,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:
@@ -389,6 +389,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "3bb000251e55d4a209aa0e2e563309dc9bb2befea2295fd0cec1f51760aac572"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.29"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   vector_math:
     dependency: transitive
     description:
@@ -422,5 +486,5 @@ packages:
     source: hosted
     version: "1.1.0"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.0"
+  dart: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   english_words: ^4.0.0
   provider: ^6.1.5
   shared_preferences: ^2.5.3
+  url_launcher: ^6.3.1
 
 dev_dependencies:
   flutter_test:

--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Bumps the version in pubspec.yaml and changelog.dart, then prints
+# suggested kChangelog entries pulled from conventional commits since
+# the last git tag.
+#
+# Usage:
+#   ./scripts/prepare_release.sh <new_version>
+#
+# Example:
+#   ./scripts/prepare_release.sh 0.2.0
+
+set -euo pipefail
+
+NEW_VERSION=${1:?"Usage: $0 <new_version>  (e.g. 0.2.0)"}
+
+# ── Update pubspec.yaml ───────────────────────────────────────────────────────
+sed -i "s/^version: .*/version: $NEW_VERSION/" pubspec.yaml
+echo "✔ pubspec.yaml → $NEW_VERSION"
+
+# ── Update kAppVersion in changelog.dart ─────────────────────────────────────
+sed -i "s/const String kAppVersion = '.*'/const String kAppVersion = '$NEW_VERSION'/" lib/data/changelog.dart
+echo "✔ changelog.dart kAppVersion → $NEW_VERSION"
+
+# ── Collect conventional commits since last tag ───────────────────────────────
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+if [ -n "$LAST_TAG" ]; then
+  COMMITS=$(git log "${LAST_TAG}..HEAD" --oneline --no-merges 2>/dev/null || echo "")
+else
+  COMMITS=$(git log --oneline --no-merges -30 2>/dev/null || echo "")
+fi
+
+FEATURE_ENTRIES=""
+FIX_ENTRIES=""
+
+while IFS= read -r line; do
+  # Strip the short hash prefix
+  MSG="${line#* }"
+  if [[ "$MSG" == feat:* ]]; then
+    DESC="${MSG#feat: }"
+    FEATURE_ENTRIES+="    ChangeEntry(ChangeType.feature, '${DESC}'),\n"
+  elif [[ "$MSG" == fix:* ]]; then
+    DESC="${MSG#fix: }"
+    FIX_ENTRIES+="    ChangeEntry(ChangeType.fix, '${DESC}'),\n"
+  fi
+done <<< "$COMMITS"
+
+# ── Print suggested kChangelog block ─────────────────────────────────────────
+echo ""
+echo "── Suggested kChangelog entry ───────────────────────────────────────────"
+echo "  '$NEW_VERSION': ["
+if [ -n "$FEATURE_ENTRIES" ]; then
+  printf "%b" "$FEATURE_ENTRIES"
+fi
+if [ -n "$FIX_ENTRIES" ]; then
+  printf "%b" "$FIX_ENTRIES"
+fi
+if [ -z "$FEATURE_ENTRIES" ] && [ -z "$FIX_ENTRIES" ]; then
+  echo "    // No feat:/fix: commits found since ${LAST_TAG:-the beginning}."
+  echo "    // Add entries manually."
+fi
+echo "  ],"
+echo "─────────────────────────────────────────────────────────────────────────"
+echo ""
+echo "Paste the block above into kChangelog in lib/data/changelog.dart,"
+echo "polish the descriptions, then commit and open a PR to main."

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,9 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
What I have currently added:

1. What's New popup

- lib/data/changelog.dart — version constant (kAppVersion), kChangelog map (released changes per version), and kDevChangelog list (unreleased changes on dev)
- lib/ui/whats_new_dialog.dart — dialog that shows on app load when the version has changed; silently records the version on first install; groups entries into New / Fixed sections
- lib/main.dart — triggers the check after the first frame via WidgetsBinding.addPostFrameCallback

2. Release automation

- scripts/prepare_release.sh — local script that bumps pubspec.yaml and kAppVersion, then prints suggested kChangelog entries from conventional commits since the last tag
- .github/workflows/validate-release-pr.yml — CI check on PRs to main; blocks merge if kAppVersion doesn't match pubspec.yaml, kChangelog has no entry for the new version, or the version wasn't bumped
- .github/workflows/release.yml — creates a GitHub Release + tag automatically when a version bump is detected on main

3. Dev build

- .github/workflows/deploy.yml — switched to JamesIves/github-pages-deploy-action; deploys main to the root of a gh-pages branch, preserving the /dev/ subfolder
- .github/workflows/deploy-dev.yml — deploys dev to the /dev/ subfolder on every push to dev
- lib/ui/settings/settings_dialog.dart — added a Developer section (web-only via kIsWeb) with an "Open dev build" button that navigates to Uri.base.resolve('dev/') in the same tab
- pubspec.yaml — added url_launcher

4. Documentation

- CONTRIBUTING.md — covers branch naming conventions, the full feature → dev → main flow, conventional commit format, the release process step-by-step, how to use the dev build for testing, the kDevChangelog workflow, CI table, and the one-time GitHub Pages setup instruction